### PR TITLE
chore: update all provider, kind, matrics and kind linux versions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ provider "kubectl" {
 
 resource "kind_cluster" "default" {
     name = var.clustername
-    node_image = "kindest/node:v1.27.1"
+    node_image = "kindest/node:v1.30.0"
     kind_config  {
         kind = "Cluster"
         api_version = "kind.x-k8s.io/v1alpha4"
@@ -208,7 +208,7 @@ resource "helm_release" "metrics" {
   create_namespace = true
   dependency_update = true
   namespace = "metrics"
-  version = "3.12.2"
+  version = "3.13.1"
   depends_on = [kind_cluster.default, local_file.kubeconfig, helm_release.cilium]
   values = [<<YAML
   defaultArgs:

--- a/prerequisites/archlinux.sh
+++ b/prerequisites/archlinux.sh
@@ -20,7 +20,7 @@ chmod +x install-opentofu.sh
 # Remove the installer:
 rm -f install-opentofu.sh
 
-[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
+[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
 
 
 chmod +x ./kind

--- a/prerequisites/debian12.sh
+++ b/prerequisites/debian12.sh
@@ -36,7 +36,7 @@ sudo groupadd docker
 sudo usermod -aG docker $USER
 newgrp docker
 
-[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
+[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
 
 
 chmod +x ./kind

--- a/prerequisites/fedora42.sh
+++ b/prerequisites/fedora42.sh
@@ -33,7 +33,7 @@ sudo usermod -aG docker $USER
 newgrp docker
 
 # Scarica e installa Kind se l'architettura è x86_64
-[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
+[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
 
 chmod +x ./kind
 sudo mv ./kind /usr/local/bin/kind

--- a/providers.tf
+++ b/providers.tf
@@ -2,15 +2,15 @@ terraform {
   required_providers {
     kind = {
       source = "tehcyx/kind"
-      version = "0.8.0"
+      version = "0.11.0"
     }
     local = {
       source = "hashicorp/local"
-      version = "~> 2.5"
+      version = "2.9.0"
     }
     helm = {
       source = "opentofu/helm"
-      version = "3.0.0-pre2"
+      version = "3.2.0"
     }
     kubectl = {
       source = "gavinbunney/kubectl"


### PR DESCRIPTION
## Update:
- kindnest/node: v1.27.1 -> 1.30.0
- metrics: 3.12.2 -> 3.13.1
- kind-linux-amd64: v0.27.0 -> v0.32.0
- tehcyx/kind: 0.8.0 -> 0.11.0
- hashicorp/local: 2.5.0 -> 2.9.0
- opentofu/helm: 3.0.0 -> 3.2.0

I've already tested this